### PR TITLE
camera_info_publisher.py

### DIFF
--- a/scripts/camera_info_publisher.py
+++ b/scripts/camera_info_publisher.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 
     # Initialize publisher node
     rospy.init_node("camera_info_publisher", anonymous=True)
-    publisher = rospy.Publisher("/jetbot_camera/camera_info", CameraInfo, queue_size=10)
+    publisher = rospy.Publisher("/jetbot_camera/camera_info", CameraInfo, queue_size=1)
     rate = rospy.Rate(10)
 
     # Run publisher


### PR DESCRIPTION
I change the buffer size to 1. Previously, this buffer starts accumulates and overtime the poses of the Apriltags are lagging behind what it actually sees. This small size ensures that the poses of the Apriltags are most up-to-date. But there is a drawback that I do notice when the control signal is published, it will almost always did not find a frame. I believe this is because the frame is flushed or maybe the publish rate is too fast (I will mark this in comment once I start the pull request). Thank you!